### PR TITLE
restore co-lux_aeterna.gabc deleted in `011c0b6`

### DIFF
--- a/co-lux_aeterna.gabc
+++ b/co-lux_aeterna.gabc
@@ -1,0 +1,19 @@
+name:Lux aeterna;
+office-part:Communio;
+mode:8;
+book:Graduale Romanum, 1961, p. 102* & The Liber Usualis, 1961, p. 1815 & Chants of the Church, 1956, p. 70;
+transcriber:Andrew Hinkley;
+%%
+(c4) LUX(h) ae(gf)tér(gh)na(g.) <v>\greheightstar</v>(,) lú(h)ce(j)at(i) e(j)is,(h) Dó(g)mi(fg)ne :(g.) *(:) Cum(h) sanc(j)tis(i) tu(j)is(h) in(i) ae(j)tér(h)num,(ghg.) (,) qui(e)a(f) pi(gh)us(h) es.(g.) (::Z) 
+
+<sp>V/</sp>. De(g) pro(h)fún(j)dis(j) cla(j)má(j)vi(j) ad(j) te,(k) Dó(k)mi(j)ne;(j.) (:) Dó(h)mi(j)ne,(j) ex(j)áu(j)di(j) vo(i)cem(j) me(h)am.(g.) (::)
+
+<v>\greheightstar</v>() Cum.(h) (::Z)
+
+<sp>V/</sp>. Fi(g)ant(h) au(j)res(j) tu(j)ae(j) in(j)ten(k)dén(k)tes(j.) (:) in(h) vo(j)cem(j) de(j)pre(j)ca(j)ti(j)ó(i)nis(j) me(h)ae.(g.) (::)
+
+<v>\greheightstar</v>() Cum.(h) (::Z)
+
+<sp>V/</sp>. Ré(g)qui(h)em(j) ae(j)tér(j)nam(j) do(j)na(j) e(j)is(k) Dó(k)mi(j)ne,(j.) (;) 
+et(h) lux(j) per(j)pé(j)tu(j)a(j) lú(j)ce(i)at(j) e(h)is.(g.) (::) 
+<v>\greheightstar</v>() Cum.(h) (::)


### PR DESCRIPTION
It looks like `co-lux_aeterna.gabc` was accidentally deleted in the last commit [011c0b6](https://github.com/marekklein/transcriptions/commit/011c0b6608c28feecc40eb13b1428b4aad749eaa#diff-dc7e260c7b3934574a30176a63623264091a86efeadd45aca8dcc5a11b4e6027).